### PR TITLE
to_json with new line

### DIFF
--- a/sfalchemy/run.py
+++ b/sfalchemy/run.py
@@ -44,6 +44,7 @@ RENDERER = dict(
     parquet=dict(func="to_parquet", params=dict(engine="auto")),
     # https://arrow.apache.org/docs/python/feather.html
     feather=dict(func="to_feather", params=dict()),
+    json=dict(func="to_json", params=dict(orient="records", lines=True)),
 )
 
 


### PR DESCRIPTION
- [JSON text files delimited by new lines](https://datatracker.ietf.org/doc/html/rfc7159#section-4)
- https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_json.html
- https://fivetran.com/docs/files#supportedfileformats

~~~py
In [1]: import pandas as pd

In [2]: pd.read_json("/tmp/sql_tcph_lineitem.sql.json", orient="records", lines=True)
Out[2]: 
  l_returnflag l_linestatus    sum_qty  sum_base_price  sum_disc_price    sum_charge    avg_qty     avg_price  avg_disc  count_order
0            A            F  377518399    5.660657e+11    5.377591e+11  5.592767e+11  25.500975  38237.151009  0.050007     14804077
1            N            F    9851614    1.476744e+10    1.402881e+10  1.459049e+10  25.522448  38257.810660  0.049973       385998
2            N            O  743124873    1.114302e+12    1.058581e+12  1.100937e+12  25.498076  38233.902923  0.050001     29144351
3            R            F  377732830    5.664311e+11    5.381109e+11  5.596348e+11  25.508385  38251.219274  0.049997     14808183
~~~